### PR TITLE
Fix date comment

### DIFF
--- a/src/date.rs
+++ b/src/date.rs
@@ -5,7 +5,7 @@ use chrono::{Duration, NaiveDate};
 pub struct DateInfo {
     /// The full `NaiveDate` instance.
     pub date: NaiveDate,
-    /// The formatted date string in the "DDMMYY" format.
+    /// The formatted date string in the "YYMMDD" format.
     pub formatted: String,
 }
 


### PR DESCRIPTION
## Summary
- fix comment in `DateInfo` to mention `YYMMDD` format

## Testing
- `cargo fmt`

------
https://chatgpt.com/codex/tasks/task_e_684269cd5870832ab2e4b08a2543c9c6